### PR TITLE
Add support to easy export("encoding") the SVG data of `SVGKImage` presentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: objective-c
-osx_image: xcode9.4
+osx_image: xcode10.2
+
+addons:
+  homebrew:
+    packages:
+    - carthage
+    update: true
 
 env:
   global:
@@ -15,10 +21,8 @@ notifications:
 before_install:
   - env
   - locale
-  - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
-  - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
-  - brew update
-  - brew upgrade carthage
+  - gem install cocoapods --no-document --quiet
+  - gem install xcpretty --no-document --quiet
   - pod --version
   - pod setup --silent > /dev/null
   - pod repo update --silent
@@ -30,7 +34,7 @@ script:
   - set -o pipefail
 
   - echo Check if the library described by the podspec can be built
-  # - pod lib lint --allow-warnings
+  - pod lib lint --allow-warnings
 
   - echo Build as dynamic frameworks
   - carthage update --platform ios,tvos,macos --configuration DEBUG

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,6 +3,7 @@ use_frameworks!
 target 'SDWebImageSVGCoder_Example' do
   platform :ios, '9.3'
   pod 'SDWebImageSVGCoder', :path => '../'
+  pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '3.x'
 
   target 'SDWebImageSVGCoder_Tests' do
     inherit! :search_paths

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - CocoaLumberjack (3.5.2):
-    - CocoaLumberjack/Core (= 3.5.2)
-  - CocoaLumberjack/Core (3.5.2)
-  - SDWebImage/Core (5.0.0)
-  - SDWebImageSVGCoder (0.1.1):
+  - CocoaLumberjack (3.5.3):
+    - CocoaLumberjack/Core (= 3.5.3)
+  - CocoaLumberjack/Core (3.5.3)
+  - SDWebImage/Core (5.0.2)
+  - SDWebImageSVGCoder (0.2.0):
     - SDWebImage/Core (~> 5.0)
     - SVGKit (>= 2.1)
   - SVGKit (2.1.0):
@@ -11,23 +11,31 @@ PODS:
 
 DEPENDENCIES:
   - SDWebImageSVGCoder (from `../`)
+  - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `3.x`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - CocoaLumberjack
     - SDWebImage
-    - SVGKit
 
 EXTERNAL SOURCES:
   SDWebImageSVGCoder:
     :path: "../"
+  SVGKit:
+    :branch: 3.x
+    :git: https://github.com/SVGKit/SVGKit.git
+
+CHECKOUT OPTIONS:
+  SVGKit:
+    :commit: cf32da55633e370e66a7ba6e003224bd67296c16
+    :git: https://github.com/SVGKit/SVGKit.git
 
 SPEC CHECKSUMS:
-  CocoaLumberjack: 118bf4a820efc641f79fa487b75ed928dccfae23
-  SDWebImage: 5de80a0302de9e377e62f47d2fa1304efff0e55f
-  SDWebImageSVGCoder: 6a369e2a2cacb24de6db073346d5076834471a55
+  CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
+  SDWebImage: 6764b5fa0f73c203728052955dbefa2bf1f33282
+  SDWebImageSVGCoder: 61f60a3064db079de646a34a5f5aa8d3ac258345
   SVGKit: 8a2fc74258bdb2abb54d3b65f3dd68b0277a9c4d
 
-PODFILE CHECKSUM: 5438d217c00bb7b2da72c6e8ce8ec9db055a4cc6
+PODFILE CHECKSUM: 8107c7193dd0c4844a782937610f415caa6ef482
 
 COCOAPODS: 1.6.1

--- a/Example/SDWebImageSVGCoder-Example-macOS/ViewController.m
+++ b/Example/SDWebImageSVGCoder-Example-macOS/ViewController.m
@@ -35,6 +35,8 @@
     [imageView1 sd_setImageWithURL:SVGURL placeholderImage:nil options:SDWebImageRetryFailed completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
         if (image) {
             NSLog(@"SVG load success");
+            NSData *svgData = [image sd_imageDataAsFormat:SDImageFormatSVG];
+            NSAssert(svgData.length > 0, @"SVG Data should exist");
         }
     }];
     [imageView2 sd_setImageWithURL:SVGURL2 placeholderImage:nil options:SDWebImageRetryFailed context:@{SDWebImageContextSVGImageSize : @(imageView2.bounds.size)} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {

--- a/Example/SDWebImageSVGCoder/SDViewController.m
+++ b/Example/SDWebImageSVGCoder/SDViewController.m
@@ -51,6 +51,8 @@
     [imageView1 sd_setImageWithURL:svgURL placeholderImage:nil options:SDWebImageRetryFailed completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
         if (image) {
             NSLog(@"SVGKLayeredImageView SVG load success");
+            NSData *svgData = [image sd_imageDataAsFormat:SDImageFormatSVG];
+            NSAssert(svgData.length > 0, @"SVG Data should exist");
         }
     }];
     [imageView2 sd_setImageWithURL:svgURL2 placeholderImage:nil options:SDWebImageRetryFailed completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {

--- a/SDWebImageSVGCoder.xcodeproj/project.pbxproj
+++ b/SDWebImageSVGCoder.xcodeproj/project.pbxproj
@@ -43,12 +43,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		328C14B62184C856006B0C4A /* SDWebImageSVGCoder_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageSVGCoder_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		328C14B62184C856006B0C4A /* SDWebImageSVGCoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageSVGCoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		328C14D02184D111006B0C4A /* SDWebImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDWebImage.framework; path = Carthage/Build/tvOS/SDWebImage.framework; sourceTree = "<group>"; };
 		328C14D22184D11F006B0C4A /* SVGKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SVGKit.framework; path = Carthage/Build/tvOS/SVGKit.framework; sourceTree = "<group>"; };
 		328C14D42184D131006B0C4A /* SVGKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SVGKit.framework; path = Carthage/Build/Mac/SVGKit.framework; sourceTree = "<group>"; };
 		328C14D62184D13B006B0C4A /* SDWebImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDWebImage.framework; path = Carthage/Build/Mac/SDWebImage.framework; sourceTree = "<group>"; };
-		32B613192170AA2900DBD6ED /* SDWebImageSVGCoder_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageSVGCoder_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		32B613192170AA2900DBD6ED /* SDWebImageSVGCoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageSVGCoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		32B613242170AA9300DBD6ED /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Module/Info.plist; sourceTree = "<group>"; };
 		32B613372170AB0F00DBD6ED /* SDImageSVGCoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDImageSVGCoder.m; sourceTree = "<group>"; };
 		32B613392170AB0F00DBD6ED /* SVGKImageView+WebCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SVGKImageView+WebCache.h"; sourceTree = "<group>"; };
@@ -61,7 +61,7 @@
 		32B613492170AB1600DBD6ED /* SDWebImageSVGCoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDWebImageSVGCoder.h; path = Module/SDWebImageSVGCoder.h; sourceTree = "<group>"; };
 		32B6134C2170B16400DBD6ED /* SVGKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SVGKit.framework; path = Carthage/Build/iOS/SVGKit.framework; sourceTree = "<group>"; };
 		32B6134E2170B17200DBD6ED /* SDWebImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDWebImage.framework; path = Carthage/Build/iOS/SDWebImage.framework; sourceTree = "<group>"; };
-		32B613552170B19800DBD6ED /* SDWebImageSVGCoder_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageSVGCoder_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		32B613552170B19800DBD6ED /* SDWebImageSVGCoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageSVGCoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		32B613572170B19800DBD6ED /* SDWebImageSVGCoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageSVGCoder.h; sourceTree = "<group>"; };
 		32B613582170B19800DBD6ED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -110,9 +110,9 @@
 		32B6131A2170AA2900DBD6ED /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				32B613192170AA2900DBD6ED /* SDWebImageSVGCoder_iOS.framework */,
-				32B613552170B19800DBD6ED /* SDWebImageSVGCoder_tvOS.framework */,
-				328C14B62184C856006B0C4A /* SDWebImageSVGCoder_macOS.framework */,
+				32B613192170AA2900DBD6ED /* SDWebImageSVGCoder.framework */,
+				32B613552170B19800DBD6ED /* SDWebImageSVGCoder.framework */,
+				328C14B62184C856006B0C4A /* SDWebImageSVGCoder.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -221,7 +221,7 @@
 			);
 			name = "SDWebImageSVGCoder macOS";
 			productName = "SDWebImageSVGCoder-macOS";
-			productReference = 328C14B62184C856006B0C4A /* SDWebImageSVGCoder_macOS.framework */;
+			productReference = 328C14B62184C856006B0C4A /* SDWebImageSVGCoder.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		32B613182170AA2900DBD6ED /* SDWebImageSVGCoder iOS */ = {
@@ -239,7 +239,7 @@
 			);
 			name = "SDWebImageSVGCoder iOS";
 			productName = SDWebImageSVGCoder;
-			productReference = 32B613192170AA2900DBD6ED /* SDWebImageSVGCoder_iOS.framework */;
+			productReference = 32B613192170AA2900DBD6ED /* SDWebImageSVGCoder.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		32B613542170B19800DBD6ED /* SDWebImageSVGCoder tvOS */ = {
@@ -257,7 +257,7 @@
 			);
 			name = "SDWebImageSVGCoder tvOS";
 			productName = SDWebImageSVGCoder;
-			productReference = 32B613552170B19800DBD6ED /* SDWebImageSVGCoder_tvOS.framework */;
+			productReference = 32B613552170B19800DBD6ED /* SDWebImageSVGCoder.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -384,8 +384,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.SDWebImageSVGCoder;
-				PRODUCT_MODULE_NAME = SDWebImageSVGCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImageSVGCoder;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};
@@ -415,8 +414,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.SDWebImageSVGCoder;
-				PRODUCT_MODULE_NAME = SDWebImageSVGCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImageSVGCoder;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};
@@ -562,8 +560,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.SDWebImageSVGCoder;
-				PRODUCT_MODULE_NAME = SDWebImageSVGCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImageSVGCoder;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -591,8 +588,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.SDWebImageSVGCoder;
-				PRODUCT_MODULE_NAME = SDWebImageSVGCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImageSVGCoder;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -619,8 +615,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.SDWebImageSVGCoder;
-				PRODUCT_MODULE_NAME = SDWebImageSVGCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImageSVGCoder;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
@@ -649,8 +644,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.SDWebImageSVGCoder;
-				PRODUCT_MODULE_NAME = SDWebImageSVGCoder;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = SDWebImageSVGCoder;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;

--- a/SDWebImageSVGCoder/Classes/SDImageSVGCoder.m
+++ b/SDWebImageSVGCoder/Classes/SDImageSVGCoder.m
@@ -6,6 +6,7 @@
 //
 
 #import "SDImageSVGCoder.h"
+#import "SDSVGImage.h"
 #import "SDWebImageSVGCoderDefine.h"
 #import <SVGKit/SVGKit.h>
 
@@ -76,11 +77,24 @@
 #pragma mark - Encode
 
 - (BOOL)canEncodeToFormat:(SDImageFormat)format {
-    return NO;
+    return format == SDImageFormatSVG;
 }
 
 - (NSData *)encodedDataWithImage:(UIImage *)image format:(SDImageFormat)format options:(SDImageCoderOptions *)options {
-    return nil;
+    // Only support SVGKImage wrapper
+    if (![image isKindOfClass:SDSVGImage.class]) {
+        return nil;
+    }
+    SVGKImage *svgImage = ((SDSVGImage *)image).SVGImage;
+    if (!svgImage) {
+        return nil;
+    }
+    SVGKSource *source = svgImage.source;
+    // Should be NSData type source
+    if (![source isKindOfClass:SVGKSourceNSData.class]) {
+        return nil;
+    }
+    return ((SVGKSourceNSData *)source).rawData;
 }
 
 #pragma mark - Helper


### PR DESCRIPTION
### PR description
See #1 

This PR introduce the feature for encoding ("export") a `SDSVGImage` wrapper, which contains a `SVGKImage`, into the original SVG raw data.

You can just use:

```objective-c
UIImage *image; // This image must be created by SDWebImage framework but not others
NSData *svgData = [image sd_imageDataAsFormat:SDImageFormatSVG];
```