### PR TITLE
Allow constraining bitmap on one length only (width or height)

### DIFF
--- a/SDWebImageSVGCoder/Classes/SDImageSVGCoder.m
+++ b/SDWebImageSVGCoder/Classes/SDImageSVGCoder.m
@@ -200,6 +200,18 @@ static inline NSString *SDBase64DecodedString(NSString *base64String) {
     
     CGFloat xRatio = targetRect.size.width / rect.size.width;
     CGFloat yRatio = targetRect.size.height / rect.size.height;
+
+    // If we specify only one length of the size (width or height) we want to keep the ratio for that length
+    if (preserveAspectRatio) {
+        if (xRatio <= 0) {
+            xRatio = yRatio;
+            targetRect.size = CGSizeMake(rect.size.width * xRatio, targetSize.height);
+        } else if (yRatio <= 0) {
+            yRatio = xRatio;
+            targetRect.size = CGSizeMake(targetSize.width, rect.size.height * yRatio);
+        }
+    }
+
     CGFloat xScale = preserveAspectRatio ? MIN(xRatio, yRatio) : xRatio;
     CGFloat yScale = preserveAspectRatio ? MIN(xRatio, yRatio) : yRatio;
     


### PR DESCRIPTION
Fix: https://github.com/SDWebImage/SDWebImageSVGCoder/issues/27

All the svgs are constrained to 34pt high
![Simulator Screen Shot - Apple Watch Series 6 - 44mm - 2020-12-11 at 11 25 11](https://user-images.githubusercontent.com/1437036/101928404-8a3e9f80-3ba3-11eb-8355-693e69a43119.png)
