### PR TITLE
Fix preserve aspect bug

### DIFF
--- a/SDWebImageSVGCoder/Classes/SDImageSVGCoder.m
+++ b/SDWebImageSVGCoder/Classes/SDImageSVGCoder.m
@@ -108,7 +108,7 @@ static inline NSString *SDBase64DecodedString(NSString *base64String) {
     if (context[SDWebImageContextSVGImagePreserveAspectRatio]) {
         preserveAspectRatio = [context[SDWebImageContextSVGImagePreserveAspectRatio] boolValue];
     } else if (options[SDImageCoderDecodePreserveAspectRatio]) {
-        preserveAspectRatio = [context[SDImageCoderDecodePreserveAspectRatio] boolValue];
+        preserveAspectRatio = [options[SDImageCoderDecodePreserveAspectRatio] boolValue];
     }
 #pragma clang diagnostic pop
     


### PR DESCRIPTION
Refactor SDWebImageSVGDecoder.decodedImageWithData so that the options argument
is properly respected when preserve aspect ratio is requested. Currently the
wrong dictionary is being looked at resulting in the options argument being
ignored.