### PR TITLE
Using try-catch for CoreSVG vector image before rendering on screen, protect some crashes for user

### DIFF
--- a/Example/SDWebImageSVGCoder/SDViewController.m
+++ b/Example/SDWebImageSVGCoder/SDViewController.m
@@ -25,6 +25,11 @@
     NSURL *svgURL = [NSURL URLWithString:@"https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/w3c.svg"];
     NSURL *svgURL2 = [NSURL URLWithString:@"https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/wikimedia.svg"];
     NSURL *svgURL3 = [NSURL URLWithString:@"https://simpleicons.org/icons/github.svg"];
+    // Some SVG will fail, this demo check them and the C++/Objc exception should be catched by SDK
+    NSURL *badSVGURL = [NSURL URLWithString:@"https://openseauserdata.com/files/b809fe0925eb3629bb1d3edb1fafcc88.svg"];
+    [SDWebImageManager.sharedManager loadImageWithURL:badSVGURL options:0 progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+        
+    }];
     
     CGSize screenSize = self.view.bounds.size;
     

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ If you still worry about the SPI usage, you can use [SDWebImageSVGKitPlugin](htt
 
 There is also another solution: [SVG-Native](https://w3c.github.io/svgwg/specs/svg-native/index.html), a new W3C standard from Adobe, which is a subset of SVG/1.1. Both Apple/Google/Microsoft already join the agreement for this standard, you can try to write your own coder using code from [SVG-native-viewer](https://github.com/adobe/svg-native-viewer/blob/master/svgnative/example/testCocoaCG/SVGNSView.mm) and adopt SVG-native for vector images.
 
+> Warning: Some user report that Apple's CoreSVG has compatible issue for some SVGs (like using non-system Font, gradient), from v1.7.0 we protect some cases, but other exceptions are un-catchable. For these crashes, either use `Render SVG as bitmap image` (see below) or edit your SVG source file to make Apple's CoeSVG compatible.
+
 ## Example
 
 To run the example project, clone the repo, and run `pod install` from the Example directory first.


### PR DESCRIPTION
### Issue

This close #43
This close #41 

However, this can only solve some of crashes, some of crashes like Danger Pointer are un-catchable