### PR TITLE
Raise minimum iOS deployment target to 15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SDWebImageSVGCoder",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)
+        .macOS(.v10_15), .iOS("15.0"), .tvOS(.v13), .watchOS(.v6)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently SDWebImage org provide 3 kinds of SVG Coder Plugin support, here is co
 | Plugin Name| Vector Image | Bitmap Image | Platform | Compatibility | Dependency |
 |---|---|---|---|---|---|
 | [SVGNativeCoder](https://github.com/SDWebImage/SDWebImageSVGNativeCoder) | NO | YES | iOS 9+ | Best and W3C standard | adobe/svg-native-viewer |
-| [SVGCoder](https://github.com/SDWebImage/SDWebImageSVGCoder) | YES | YES | iOS 13+ | OK but buggy on some SVG | Apple CoreSVG(Private) |
+| [SVGCoder](https://github.com/SDWebImage/SDWebImageSVGCoder) | YES | YES | iOS 15+ | OK but buggy on some SVG | Apple CoreSVG(Private) |
 | [SVGKitPlugin](https://github.com/SDWebImage/SDWebImageSVGKitPlugin) | YES | NO | iOS 9+ | Worst, no longer maintain | SVGKit/SVGKit    
 
 ## What's for
@@ -52,7 +52,7 @@ You can modify the code or use some other SVG files to check the compatibility.
 
 ## Requirements
 
-+ iOS 13+
++ iOS 15+
 + tvOS 13+
 + macOS 10.15+
 + watchOS 6+
@@ -220,13 +220,13 @@ This framework supports backward deployment on iOS 12-/macOS 10.14-. And you can
 For CocoaPods user, you can skip the platform version validation in Podfile with:
 
 ```ruby
-platform :ios, '13.0' # This does not effect your App Target's deployment target version, just a hint for CocoaPods
+platform :ios, '15.0' # This does not effect your App Target's deployment target version, just a hint for CocoaPods
 ```
 
 Pay attention, you should always use the runtime version check to ensure those symbols are available, you should mark all the classes use public API with `API_AVAILABLE` annotation as well. See below:
 
 ```objective-c
-if (@available(iOS 13, *)) {
+if (@available(iOS 15, *)) {
     [SDImageCodersManager.sharedCoder addCoder:SDImageSVGCoder.sharedCoder];
 } else {
     [SDImageCodersManager.sharedCoder addCoder:SDImageSVGKCoder.sharedCoder];

--- a/SDWebImageSVGCoder.podspec
+++ b/SDWebImageSVGCoder.podspec
@@ -26,7 +26,7 @@ TODO: Add long description of the pod here.
   s.author           = { 'lizhuoli1126@126.com' => 'lizhuoli1126@126.com' }
   s.source           = { :git => 'https://github.com/SDWebImage/SDWebImageSVGCoder.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '13.0'
+  s.ios.deployment_target = '15.0'
   s.tvos.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
   s.watchos.deployment_target = '6.0'


### PR DESCRIPTION
Resolves #59.

Xcode 27 beta no longer supports iOS deployment targets below **iOS 15**. The current `.iOS(.v13)` / `s.ios.deployment_target = '13.0'` declarations emit a `the iOS deployment target ... is set to 13.0, but the range of supported deployment target versions is 15.0 to ...` warning when building under Xcode 27.

### Changes
- `Package.swift`: iOS platform floor `13.0` → `15.0`
- `SDWebImageSVGCoder.podspec`: `s.ios.deployment_target` `13.0` → `15.0`

The SwiftPM change uses the string form `.iOS("15.0")` rather than `.iOS(.v15)` because the `.v15` enum case is unavailable at this package's `swift-tools-version:5.1`.

### Verification
Built clean against the **iOS 27 SDK (Xcode 27.0 beta, 27A5194q)** for `generic/platform=iOS Simulator` — `** BUILD SUCCEEDED **`, no deployment-target warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the minimum iOS deployment target to 15.0 across the package and podspec. Devices on earlier iOS versions may no longer be compatible.
* **Documentation**
  * Updated README and compatibility guidance (including backward-deployment examples) to reflect iOS 15+ requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->